### PR TITLE
feat(Editor): add formatting provider

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,8 @@
     "lodash.throttle": "^4.1.1",
     "monaco-editor": "0.36.1",
     "petite-vue-i18n": "11.1.1",
+    "prettier": "^3.5.2",
+    "prettier-plugin-glsl": "^0.2.0",
     "tweakpane": "^3.1.10",
     "vue": "^3.5.13"
   },
@@ -41,7 +43,6 @@
     "html-minifier-terser": "^7.2.0",
     "lightningcss": "^1.29.1",
     "postcss-size": "^5.0.0",
-    "prettier": "^3.5.2",
     "pug": "^3.0.3",
     "rollup-plugin-visualizer": "^5.14.0",
     "sitemap": "^7.1.1",
@@ -56,7 +57,8 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "monaco-editor@0.36.1": "patches/monaco-editor@0.36.1.patch"
+      "monaco-editor@0.36.1": "patches/monaco-editor@0.36.1.patch",
+      "prettier-plugin-glsl": "patches/prettier-plugin-glsl.patch"
     },
     "overrides": {
       "@shaderfrog/glsl-parser": "link:..\\..\\glsl-parser"

--- a/app/patches/prettier-plugin-glsl.patch
+++ b/app/patches/prettier-plugin-glsl.patch
@@ -1,0 +1,58 @@
+diff --git a/lib/prettier-plugin.cjs.js b/lib/prettier-plugin.cjs.js
+index 96089b8baa0d4fc6defe1ac912bd70e708fbb72f..b8ae31f696d7eb37e76e92b2836f2d68ab21452c 100644
+--- a/lib/prettier-plugin.cjs.js
++++ b/lib/prettier-plugin.cjs.js
+@@ -1,8 +1,7 @@
+ 'use strict';
+ 
+-var prettier = require('prettier');
+-var doc = require('prettier/doc');
+-var lodash = require('lodash');
++var prettier = require('prettier/standalone');
++var doc = prettier.doc; // require('prettier/doc');
+ var chevrotain = require('chevrotain');
+ 
+ function _interopNamespaceDefault(e) {
+@@ -910,7 +909,7 @@ var TOKEN;
+ })(TOKEN || (TOKEN = {}));
+ // IDENTIFIER needs to go last, but must be declared first
+ // so it can be referenced in longerAlt
+-const ALL_TOKENS = lodash.pull(Object.values(TOKEN), TOKEN.NON_PP_IDENTIFIER).flatMap((x) => (Array.isArray(x) ? x : [x]));
++const ALL_TOKENS = Object.values(TOKEN).filter(k => k !== TOKEN.NON_PP_IDENTIFIER).flatMap((x) => (Array.isArray(x) ? x : [x]));
+ ALL_TOKENS.push(TOKEN.NON_PP_IDENTIFIER);
+ const GLSL_LEXER = new chevrotain.Lexer(ALL_TOKENS, { ensureOptimizations: DEV });
+ function checkLexingErrors(input, lexingResult) {
+@@ -982,7 +981,7 @@ function isBitwiseOperator(tokenType) {
+ new (class extends AbstractVisitor {
+     constructor() {
+         super(...arguments);
+-        this.markError = lodash.noop;
++        this.markError = () => {};
+     }
+     eval(n, isDefined, markError) {
+         this.isDefined = isDefined;
+@@ -3189,7 +3188,7 @@ const printers = {
+                         parts.push(opening);
+                         if (n.no) {
+                             const commentOnOwnLine = n.yes.comments?.some((c) => c.trailing && c.tokenType === TOKEN.LINE_COMMENT) ||
+-                                lodash.findLast(n.yes.comments, (c) => !c.leading && !c.trailing)
++                                n.yes.comments.findLast((c) => !c.leading && !c.trailing)
+                                     ?.tokenType === TOKEN.LINE_COMMENT;
+                             const elseOnSameLine = n.yes.kind === "compoundStatement" && !commentOnOwnLine;
+                             parts.push(elseOnSameLine ? " " : hardline);
+diff --git a/package.json b/package.json
+index 5288492a36bddf02f0eebc28b424a77e285a5663..6cb4510d78ff195bdcbbf5dc215e758af0f32116 100644
+--- a/package.json
++++ b/package.json
+@@ -11,7 +11,10 @@
+   ],
+   "version": "0.2.0",
+   "description": "Prettier (https://prettier.io) plugin for GLSL (OpenGL Shading Language).",
+-  "exports": "./lib/prettier-plugin.cjs.js",
++  "exports": {
++    "default": "./lib/prettier-plugin.cjs.js",
++    "types": "./lib/prettier-plugin.d.ts"
++  },
+   "type": "commonjs",
+   "types": "lib/prettier-plugin.d.ts",
+   "scripts": {

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   monaco-editor@0.36.1:
     hash: 7474beaceeed1b1c167b83f5a17b741511554bdf142686d52c91066dbbb57a8b
     path: patches/monaco-editor@0.36.1.patch
+  prettier-plugin-glsl:
+    hash: 66aeaeb502d565e88882e3caf59001309e56a640b8a84793686da60b7da5f880
+    path: patches/prettier-plugin-glsl.patch
 
 importers:
 
@@ -49,6 +52,12 @@ importers:
       petite-vue-i18n:
         specifier: 11.1.1
         version: 11.1.1(vue@3.5.13(typescript@5.7.3))
+      prettier:
+        specifier: ^3.5.2
+        version: 3.5.2
+      prettier-plugin-glsl:
+        specifier: ^0.2.0
+        version: 0.2.0(patch_hash=66aeaeb502d565e88882e3caf59001309e56a640b8a84793686da60b7da5f880)(prettier@3.5.2)
       tweakpane:
         specifier: ^3.1.10
         version: 3.1.10
@@ -95,9 +104,6 @@ importers:
       postcss-size:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.3)
-      prettier:
-        specifier: ^3.5.2
-        version: 3.5.2
       pug:
         specifier: ^3.0.3
         version: 3.0.3
@@ -736,6 +742,18 @@ packages:
   '@brillout/vite-plugin-import-build@0.2.22':
     resolution: {integrity: sha512-n5sv0HdCB5WC2QJSnTN6iS/F+sJsF0AmtsCCaQ+5+dRjgsoGGsa3auinJV8tuEog5WsX+3MF8RIwn3A/u0e04w==}
 
+  '@chevrotain/cst-dts-gen@10.5.0':
+    resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
+
+  '@chevrotain/gast@10.5.0':
+    resolution: {integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==}
+
+  '@chevrotain/types@10.5.0':
+    resolution: {integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==}
+
+  '@chevrotain/utils@10.5.0':
+    resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
 
@@ -1349,6 +1367,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.7':
     resolution: {integrity: sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==}
+
+  '@netflix/nerror@1.1.3':
+    resolution: {integrity: sha512-b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2057,6 +2078,10 @@ packages:
   assert-never@1.4.0:
     resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
 
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   ast-kit@1.4.0:
     resolution: {integrity: sha512-BlGeOw73FDsX7z0eZE/wuuafxYoek2yzNJ6l6A1nsb4+z/p87TOPbHaWuN53kFKNuUXiCQa2M+xLF71IqQmRSw==}
     engines: {node: '>=16.14.0'}
@@ -2217,6 +2242,9 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  chevrotain@10.5.0:
+    resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -2545,6 +2573,10 @@ packages:
   extract-files@11.0.0:
     resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  extsprintf@1.4.1:
+    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
+    engines: {'0': node >=0.6.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3552,6 +3584,11 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier-plugin-glsl@0.2.0:
+    resolution: {integrity: sha512-077OZowcSipMbRZgEZpJAmg00sNbBh+P0rPrsz0TKKDRPJuLHaEoZLDhjqLV+eAqvKrdzaLlLblDdxCrQPcMlg==}
+    peerDependencies:
+      prettier: ^3.0.0
+
   prettier@3.5.2:
     resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
     engines: {node: '>=14'}
@@ -3644,6 +3681,9 @@ packages:
 
   regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
+
+  regexp-to-ast@0.5.0:
+    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -5229,6 +5269,21 @@ snapshots:
     dependencies:
       '@brillout/import': 0.2.3
 
+  '@chevrotain/cst-dts-gen@10.5.0':
+    dependencies:
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/gast@10.5.0':
+    dependencies:
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/types@10.5.0': {}
+
+  '@chevrotain/utils@10.5.0': {}
+
   '@emnapi/core@1.3.1':
     dependencies:
       '@emnapi/wasi-threads': 1.0.1
@@ -5935,6 +5990,12 @@ snapshots:
       '@emnapi/runtime': 1.3.1
       '@tybys/wasm-util': 0.9.0
     optional: true
+
+  '@netflix/nerror@1.1.3':
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.4.1
+      lodash: 4.17.21
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6685,6 +6746,8 @@ snapshots:
 
   assert-never@1.4.0: {}
 
+  assert-plus@1.0.0: {}
+
   ast-kit@1.4.0:
     dependencies:
       '@babel/parser': 7.26.9
@@ -6884,6 +6947,15 @@ snapshots:
       is-regex: 1.2.1
 
   chardet@0.7.0: {}
+
+  chevrotain@10.5.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 10.5.0
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      '@chevrotain/utils': 10.5.0
+      lodash: 4.17.21
+      regexp-to-ast: 0.5.0
 
   chokidar@3.5.3:
     dependencies:
@@ -7277,6 +7349,8 @@ snapshots:
       tmp: 0.0.33
 
   extract-files@11.0.0: {}
+
+  extsprintf@1.4.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -8300,6 +8374,13 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prettier-plugin-glsl@0.2.0(patch_hash=66aeaeb502d565e88882e3caf59001309e56a640b8a84793686da60b7da5f880)(prettier@3.5.2):
+    dependencies:
+      '@netflix/nerror': 1.1.3
+      chevrotain: 10.5.0
+      lodash: 4.17.21
+      prettier: 3.5.2
+
   prettier@3.5.2: {}
 
   pretty-bytes@5.6.0: {}
@@ -8422,6 +8503,8 @@ snapshots:
   regenerator-transform@0.15.2:
     dependencies:
       '@babel/runtime': 7.26.9
+
+  regexp-to-ast@0.5.0: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:

--- a/app/src/format.ts
+++ b/app/src/format.ts
@@ -1,0 +1,30 @@
+// @note explicitly import cjs version so it doesn't get bundled twice (mjs here and cjs in plugin-glsl)
+import { format, formatWithCursor } from "prettier/standalone.js";
+import type { Options as PrettierOptions } from "prettier";
+import * as glslPlugin from "prettier-plugin-glsl";
+
+const formatOptions = {
+  printWidth: 75,
+  tabWidth: 4,
+  endOfLine: "lf",
+} satisfies PrettierOptions;
+
+export const formatCode = async (code: string, offset: number) => {
+  // @todo this breaks sometimes due to different cursor position, something's with offset
+  // const formattingResult = await formatWithCursor(code, {
+  //   cursorOffset: offset,
+  //   plugins: [glslPlugin],
+  //   filepath: "shader.glsl",
+  //   ...formatOptions,
+  // });
+
+  // return formattingResult;
+
+  const formatted = await format(code, {
+    parser: "glsl-parser",
+    plugins: [glslPlugin],
+    ...formatOptions,
+  });
+
+  return { formatted };
+};

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig(({ command }) => ({
       // @ts-expect-error
       filename: `sw-${Math.floor(new Date() / 1000).toString(32)}.js`,
       workbox: {
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         // @note use slash, because default is /index.html which is incorrect since we use /index.php
         // @note but this https://github.com/vite-pwa/nuxt/issues/53#issuecomment-1615266204
         navigateFallback: undefined,
@@ -172,7 +172,7 @@ export default defineConfig(({ command }) => ({
 
   build: {
     cssMinify: "lightningcss",
-    // sourcemap: "hidden", // @todo
+    sourcemap: true, // @todo wait for css modules plugin update with correct source maps
     minify: "terser",
     target: "es2022",
     terserOptions: {


### PR DESCRIPTION
- Patch `prettier-glsl-plugin` for proper type exports, standalone (browser) prettier, lodash removal, prettier/docs dedupe (use from standalone.js). Close #28
- Add Ctrl-Shift-P shortcut for command palette instead of default F1