### PR TITLE
Update default.frag with fixed comment

### DIFF
--- a/app/src/default.frag
+++ b/app/src/default.frag
@@ -14,7 +14,7 @@ out vec4 out_color;
 uniform vec2 u_resolution;
 // elapsed time since shader compile in seconds
 uniform float u_time;
-// mouse pixel coordinates are in canvas space, (0,0) is top left
+// mouse pixel coordinates are in canvas space, (0,0) is bottom left, (u_resolution.x,u_resolution.y) is top right
 uniform vec4 u_mouse;
 // texture array
 uniform sampler2D u_textures[16];


### PR DESCRIPTION
There is a comment that has inaccurate information on line 17 - it claims that the y-coordinate of the mouse starts at the top at 0 pixels and increases as it goes down, however the y-coordinate of the mouse starts at the bottom at 0 pixels and increases as it goes up. This change is to prevent new users learning glsl from being confused by the behavior of the mouse.